### PR TITLE
Exposed generateFromTemplate off of $.mockJSON

### DIFF
--- a/js/jquery.mockjson.js
+++ b/js/jquery.mockjson.js
@@ -27,7 +27,7 @@ $.ajax = function(options) {
         for (var i = 0; i < _mocked.length; i++) {
             var mock = _mocked[i];
             if (mock.request.test(options.url)) {
-                options.success(generateFromTemplate(mock.template));
+                options.success($.mockJSON.generateFromTemplate(mock.template));
                 return $;
             }
         }

--- a/js/jquery.mockjson.js
+++ b/js/jquery.mockjson.js
@@ -37,7 +37,7 @@ $.ajax = function(options) {
 }
 
 
-function generateFromTemplate(template, name) {
+$.mockJSON.generateFromTemplate = function(template, name) {
     var length = 0;
     var matches = (name || '').match(/\w+\|(\d+)-(\d+)/);
     if (matches) {
@@ -51,14 +51,14 @@ function generateFromTemplate(template, name) {
         case 'array':
             generated = [];
             for (var i = 0; i < length; i++) {
-                generated[i] = generateFromTemplate(template[0]);
+                generated[i] = $.mockJSON.generateFromTemplate(template[0]);
             }
             break;
 
         case 'object':
             generated = {};
             for (var p in template) {
-                generated[p.replace(/\|\d+-\d+/, '')] = generateFromTemplate(template[p], p);
+                generated[p.replace(/\|\d+-\d+/, '')] = $.mockJSON.generateFromTemplate(template[p], p);
             }
             break;
 


### PR DESCRIPTION
Both mockjax and mockJSON both have the url matching capability, but mockJSON exceeds in it's templating capability and mockjax exceeds in it's combination of ajax settings.

By exposing generageFromTemplate the two libraries can play nicely together as seen in the following example...

http://jsfiddle.net/elijahmanor/hkTv2/20/

$.mockjax({
    url: '/contact/list',
    responseTime: 750,
    headers: {
        etag: 'xyz123'
    },
    responseText: $.mockJSON.generateFromTemplate({
        "fathers|5-10": [
            {
            "married|0-1": true,
            "name": "@MALE_FIRST_NAME @LAST_NAME",
            "sons": null,
            "daughters|0-3": [
                {
                "age|0-31": 0,
                "name": "@FEMALE_FIRST_NAME"}
            ]}
        ]
    })
});

$.ajax({
    url: "/contact/list",
    type: "GET",
    dataType: "json",
    success: function(data, textStatus, xhr) {
        console.log("Data returned: " + data.fathers);
    },
    error: function(xhr, textStatus, errorThrown) {
        console.log("Error: " + textStatus);
    }
});
