### PR TITLE
Honour JavaScript Number types when template generates random number data.

### DIFF
--- a/js/jquery.mockjson.js
+++ b/js/jquery.mockjson.js
@@ -89,7 +89,10 @@ $.mockJSON.generateFromTemplate = function(template, name) {
                 var keys = generated.match(/@([A-Z_0-9\(\),]+)/g) || [];
                 for (var i = 0; i < keys.length; i++) {
                     var key = keys[i];
-                    generated = generated.replace(key, getRandomData(key));
+                    var randomData = getRandomData(key);
+                    generated = generated.replace(key, randomData);
+                    if (type(randomData) == 'number')
+                        generated = Number(generated);
                 }
             } else {
                 generated = ""


### PR DESCRIPTION
If a template generates random numbers, allow the number to come back as a JavaScript number and not a string representation of the number.
